### PR TITLE
fix macappstore URL

### DIFF
--- a/payload/Library/Application Support/nudge/Resources/nudge
+++ b/payload/Library/Application Support/nudge/Resources/nudge
@@ -252,7 +252,7 @@ def update_app_path():
     if os.path.exists(software_updates_prefpane):
         return 'file://{}'.format(software_updates_prefpane)
     else:
-        return 'macappstore://updates'
+        return 'macappstore://showUpdatesPage'
 
 
 def pkgregex(pkgpath):


### PR DESCRIPTION
The macappstore URL in update_app_path() should be macappstore://showUpdatesPage, at least for 10.11 and up.